### PR TITLE
[NO-ISSUE] Add GitHub Actions workflow for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI/CD using github actions
+
+on: [ push, pull_request, workflow_dispatch ]
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build
+        run: swift build
+
+  test:
+    needs: build
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test
+        run: swift test


### PR DESCRIPTION
- Configured the workflow to run on push, pull request, and manual dispatch events
- Included jobs for building and testing the project using Swift on macOS
- The build job checks out the code and runs `swift build`
- The test job depends on the build job, checks out the code, and runs `swift test`