### PR TITLE
Improvement: Allow authentication context usage

### DIFF
--- a/Sources/WebAuthn/Authenticator/Authenticator.swift
+++ b/Sources/WebAuthn/Authenticator/Authenticator.swift
@@ -13,6 +13,7 @@
 // under the License.
 
 import Foundation
+import LocalAuthentication
 
 protocol Authenticator {
     var type: AuthenticatorType { get }
@@ -26,14 +27,16 @@ protocol Authenticator {
         userEntity: PublicKeyCredentialUserEntity,
         credTypesAndPubKeyAlgs: [PublicKeyCredentialParameters],
         excludeCredentialDescriptorList: [PublicKeyCredentialDescriptor]?,
-        extensions: AuthenticatorExtensionsInput?
+        extensions: AuthenticatorExtensionsInput?,
+        context: LAContext?
     ) async -> Result<AuthenticatorMakeCredentialResult, WebAuthnError>
 
     func getAssertion(
         rpId: String,
         hash: Data,
         allowCredentialDescriptorList: [PublicKeyCredentialDescriptor]?,
-        extensions: AuthenticatorExtensionsInput?
+        extensions: AuthenticatorExtensionsInput?,
+        context: LAContext?
     ) async -> Result<AuthenticatorGetAssertionResult, WebAuthnError>
 }
 
@@ -98,7 +101,8 @@ extension Authenticator {
                         userEntity: PublicKeyCredentialUserEntity,
                         credTypesAndPubKeyAlgs: [PublicKeyCredentialParameters],
                         excludeCredentialDescriptorList: [PublicKeyCredentialDescriptor]?,
-                        extensions: AuthenticatorExtensionsInput?
+                        extensions: AuthenticatorExtensionsInput?,
+                        context: LAContext?
     ) async -> Result<AuthenticatorMakeCredentialResult, WebAuthnError> {
         do {
             guard let matchedKeyParam = checkCredTypesAndPubKeyAlgsSupported(credTypesAndPubKeyAlgs) else {
@@ -109,8 +113,10 @@ extension Authenticator {
             guard isNotRegistered else {
                 throw WebAuthnError.coreError(.invalidStateError)
             }
-            guard try await localAuthn.execute().get() else {
-                throw WebAuthnError.coreError(.notAllowedError)
+            if context == nil {
+                guard try await localAuthn.execute().get() else {
+                    throw WebAuthnError.coreError(.notAllowedError)
+                }
             }
             guard let credentialId = generateRandomBytes(len: 32) else {
                 throw WebAuthnError.utilityError(cause: "Failed to generate random bytes")
@@ -138,7 +144,7 @@ extension Authenticator {
             _ = try credSrcStorage.store(credSource).mapError { e in
                 WebAuthnError.credSrcStorageError(e, credId: credSource.id)
             }.get()
-            _ = try keyStorage.store(credSource.id, key: priKey).mapError { e in
+            _ = try keyStorage.store(credSource.id, key: priKey, context: context).mapError { e in
                 WebAuthnError.keyStorageError(e, credId: credSource.id)
             }.get()
             return .success(AuthenticatorMakeCredentialResult(credentialId: credentialId,
@@ -154,7 +160,8 @@ extension Authenticator {
     func getAssertion(rpId: String,
                       hash: Data,
                       allowCredentialDescriptorList: [PublicKeyCredentialDescriptor]?,
-                      extensions: AuthenticatorExtensionsInput?
+                      extensions: AuthenticatorExtensionsInput?,
+                      context: LAContext?
     ) async -> Result<AuthenticatorGetAssertionResult, WebAuthnError> {
         do {
             let credentialOptions = try checkAllowedCredentials(rpId, allowCredentialDescriptorList).get()
@@ -164,7 +171,7 @@ extension Authenticator {
             let selectedCredential = credentialOptions[0]
             let credId = selectedCredential.id
             let rpIdHash = rpId.toSHA256()
-            let key = try keyStorage.load(credId).mapError { e in
+            let key = try keyStorage.load(credId, context: context).mapError { e in
                 WebAuthnError.keyStorageError(e, credId: credId)
             }.get()
             guard let key = key else {

--- a/Sources/WebAuthn/PublicKeyCredential/PublicKeyCredential.swift
+++ b/Sources/WebAuthn/PublicKeyCredential/PublicKeyCredential.swift
@@ -13,6 +13,7 @@
 // under the License.
 
 import Foundation
+import LocalAuthentication
 
 // It can be possible to generate several `PublicKeyCredential` instances
 // concurrently. It means that multiple accounts can be registered for one user.
@@ -52,7 +53,7 @@ extension PublicKeyCredential {
     /// This method allows you to register a user credential by generating an
     /// asymmetric key pair. The private key is securely stored on the client
     /// side, while the public key is stored by the relying party.
-    public func create(_ options: RP.RegOpts) async -> Result<Bool, WebAuthnError> {
+    public func create(_ options: RP.RegOpts, context: LAContext?) async -> Result<Bool, WebAuthnError> {
         var credIdStr: String?
         do {
             let data = try await rp.getRegistrationData(options).mapError { e in
@@ -91,7 +92,8 @@ extension PublicKeyCredential {
                 userEntity: createOptions.user,
                 credTypesAndPubKeyAlgs: credTypesAndPubKeyAlgs,
                 excludeCredentialDescriptorList: createOptions.excludeCredentials,
-                extensions: createOptions.extensions?.processAuthenticatorExtensionsInput()).get()
+                extensions: createOptions.extensions?.processAuthenticatorExtensionsInput(),
+                context: context).get()
             credIdStr = authnResult.credentialId.toBase64Url()
             let createResult = PublicKeyCredentialCreateResult(
                 id: authnResult.credentialId,
@@ -132,7 +134,7 @@ extension PublicKeyCredential {
 
     /// This method allows you to authenticate a user by communicating with a
     /// relying party using a previously registered credential.
-    public func get(_ options: RP.AuthnOpts) async -> Result<Bool, WebAuthnError> {
+    public func get(_ options: RP.AuthnOpts, context: LAContext?) async -> Result<Bool, WebAuthnError> {
         do {
             let data = try await rp.getAuthenticationData(options).mapError { e in
                 WebAuthnError.rpError(e)
@@ -157,7 +159,8 @@ extension PublicKeyCredential {
                 rpId: getOptions.rpId,
                 hash: clientDataJson.toSHA256(),
                 allowCredentialDescriptorList: getOptions.allowCredentials,
-                extensions: getOptions.extensions?.processAuthenticatorExtensionsInput()).get()
+                extensions: getOptions.extensions?.processAuthenticatorExtensionsInput(),
+                context: context).get()
             let getResult = PublicKeyCredentialGetResult(
                 id: authnResult.credentialId,
                 clientDataJson: clientDataJson,

--- a/Sources/WebAuthn/Storage/KeyStorage.swift
+++ b/Sources/WebAuthn/Storage/KeyStorage.swift
@@ -13,6 +13,7 @@
 // under the License.
 
 import Foundation
+import LocalAuthentication
 
 public final class KeyStorage {
     private let keychain: KeychainProtocol
@@ -29,12 +30,15 @@ public final class KeyStorage {
         }
     }
 
-    func load(_ kid: String) -> Result<SecKey?, KeyStorageError> {
-        let query: [String: Any] = [
+    func load(_ kid: String, context: LAContext? = nil) -> Result<SecKey?, KeyStorageError> {
+        var query: [String: Any] = [
             kSecClass as String: kSecClassKey,
             kSecAttrLabel as String: kid,
             kSecReturnRef as String: true
         ]
+        if let context {
+            query[kSecUseAuthenticationContext as String] = context
+        }
         var queryResult: AnyObject?
         let keychainResponse = keychain.get(query)
         queryResult = keychainResponse.queryResult
@@ -51,17 +55,20 @@ public final class KeyStorage {
         return .success((item as! SecKey))
     }
 
-    func store(_ id: String, key: SecKey) -> Result<(), KeyStorageError> {
-        let result = load(id)
+    func store(_ id: String, key: SecKey, context: LAContext? = nil) -> Result<(), KeyStorageError> {
+        let result = load(id, context: context)
         switch result {
         case .failure(let error):
             return .failure(error)
         case .success(let val):
             if let _ = val {
-                let query: [String: Any] = [
+                var query: [String: Any] = [
                     kSecClass as String: kSecClassKey,
                     kSecAttrLabel as String: id
                 ]
+                if let context {
+                    query[kSecUseAuthenticationContext as String] = context
+                }
                 let attributes: [String: Any] = [kSecValueRef as String: key]
                 let status = keychain.update(query, with: attributes)
                 guard status == errSecSuccess else {
@@ -71,12 +78,15 @@ public final class KeyStorage {
                 guard let access = access else {
                     return .failure(.accessFailed)
                 }
-                let query: [String: Any] = [
+                var query: [String: Any] = [
                     kSecClass as String: kSecClassKey,
                     kSecAttrLabel as String: id,
                     kSecAttrAccessControl as String: access,
                     kSecValueRef as String: key
                 ]
+                if let context {
+                    query[kSecUseAuthenticationContext as String] = context
+                }
                 let status = keychain.add(query)
                 guard status == errSecSuccess else {
                     return .failure(.storeFailed(status: status))


### PR DESCRIPTION
## Context
Currently the library takes care of the policy evaluation for us. But what if we want to perform such evaluation beforehand? Or reuse an already evaluated context, to avoid requesting user authorisation again?

Goal of this PR is to allow injecting an already evaluated _LAContext_ to the library, to serve as the necessary authorisation context.

## Changes
- [x] Allows the injection of an (evaluated) _LAContext_ as authentication proof.